### PR TITLE
54 slots inventory

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/InternalMenu.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/InternalMenu.java
@@ -61,7 +61,7 @@ public class InternalMenu implements UpgradesIndex {
         ITeam team = a.getTeam(player);
         if (team == null) return;
         if (!BedWars.getAPI().getArenaUtil().isPlaying(player)) return;
-        Inventory inv = Bukkit.createInventory(null, 45, Language.getMsg(player, Messages.UPGRADES_MENU_GUI_NAME_PATH + name));
+        Inventory inv = Bukkit.createInventory(null, 54, Language.getMsg(player, Messages.UPGRADES_MENU_GUI_NAME_PATH + name));
         for (Map.Entry<Integer, MenuContent> entry : menuContentBySlot.entrySet()) {
             inv.setItem(entry.getKey(), entry.getValue().getDisplayItem(player, team));
         }


### PR DESCRIPTION
for better upgrades menu overlay (https://i.imgur.com/VawNpJB.png)

bedwars1058 is using spigot-1.8 so we can create a 54 slots inventory since there wasn't any type of validation on it, but it may break if bedwars1058 upgrade to higher api version